### PR TITLE
[OPS-5574] Add support for forwarding a request path.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/webhookrelay/WebhookReceiver.java
+++ b/src/main/java/org/jenkinsci/plugins/webhookrelay/WebhookReceiver.java
@@ -74,7 +74,7 @@ public class WebhookReceiver extends WebSocketClient {
         }
 
         // for debug purpose, try to extract some useful infos from received event :
-        if (body != null) {
+        if (body != null && postBack != null && postBack.startsWith("/github-webhook")) {
             try {
                 JSONObject bodyJson = JSONObject.fromObject(body);
                 JSONObject repo = bodyJson.getJSONObject("repository");

--- a/src/main/java/org/jenkinsci/plugins/webhookrelay/WebhookReceiver.java
+++ b/src/main/java/org/jenkinsci/plugins/webhookrelay/WebhookReceiver.java
@@ -54,12 +54,12 @@ public class WebhookReceiver extends WebSocketClient {
         JSONObject json = JSONObject.fromObject(message);
         JSONObject headers = json.getJSONObject("headers");
         String body = json.getString("body");
-
+        String postBack = json.getString("requestPath");
+        
         HttpClient client = HttpClientBuilder.create().build();
-        String postback = "github-webhook/";
 
         String baseUrl = rootUrl != null ? rootUrl : Jenkins.getInstance().getRootUrl();
-        HttpPost post = new HttpPost(baseUrl + postback);
+        HttpPost post = new HttpPost(baseUrl + postBack);
         String contentType = "application/json";
 
         for (Object k : headers.names()) {


### PR DESCRIPTION
The plugin currently forward any message to `/github-webhook/`. This is a proposal to support any extra path send by the [webhook-relay](https://github.com/michaelneale/webhook-relay).

**(This requires an improvement of the `webhook-relay`, see https://github.com/michaelneale/webhook-relay/pull/5)**

The webhook-relay sends a `requestPath` in the published message which can be forwarded by the `webhook-relay-plugin`.

For example, the following command:

> curl -H "Content-Type: application/json" -X POST -d '{"test": "success"}' http://localhost:8082/publish/1q2w3e4r/webhooks/hjPsM59/

Publish a message like the following:

```
{"body": "{\"test\": \"success\"}", "headers": {"Host": "localhost:8082", "Content-Type": "application/json", "Content-Length": "19", "Accept": "*/*", "User-Agent": "curl/7.54.0"}, "requestPath": "/webhooks/hjPsM59/"}
```

If I have Jenkins running at `http://localhost:8081` and subscribed, the message is forwarded to `http://localhost:8081/webhooks/hjPsM59/`