### PR TITLE
Adds a link to the Confluence page describing how to get this going

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ There are two components in the webhook-relay universe:
 
 # webhook-relay
 
-The code for the webhook-relay and information on configuration can be found in <other repo>
+The code for the webhook-relay and information on configuration can be found on the following Confluence page:
+
+* [Engineering Operations / Projects / Webhook Relay](https://cloudbees.atlassian.net/wiki/spaces/OPS/pages/234782792/webhook-relay)
 
 ## Network Architecture
 


### PR DESCRIPTION
# Description

Just a simple README change to point users to [this Confluence page](https://cloudbees.atlassian.net/wiki/spaces/GAUNTLET/pages/89555867/Github+Triggers) for help getting this going.